### PR TITLE
Adding content length to response headers

### DIFF
--- a/responses/Response.js
+++ b/responses/Response.js
@@ -10,7 +10,7 @@ const BODY_ENCODING = "text";
  * 
  * @type {Object}
  */
-const headers = {
+const headers = (contentLength) => ({
   "access-control-allow-origin": [{
     key: "Access-Control-Allow-Origin",
     value: "http://localhost:3000"
@@ -26,9 +26,17 @@ const headers = {
    "access-control-max-age": [{
     key: "Access-Control-Max-Age",
     value: "86400"
+  }],
+    "content-length": [{
+    key: "Content-Length",
+    value: contentLength
   }]
-};
+});
 
+/**
+ * Exports
+ * @type {class} export
+ */
 module.exports = class extends Object {
   /**
    * Uses #headers
@@ -41,7 +49,7 @@ module.exports = class extends Object {
    */
   response(body = null) {
     return {
-      headers,
+      headers: headers(Buffer.from(body).length),
       body: body || this.statusDescription,
       bodyEncoding: BODY_ENCODING,
       status: this.status,

--- a/responses/Response.js
+++ b/responses/Response.js
@@ -44,12 +44,12 @@ module.exports = class extends Object {
    * @param  {Object} body              JSON Body
    * @param  {String} status            HTTP Status Code
    * @param  {String} statusDescription HTTP Status Description
-   * @param  {String} bodyEncoding      'text' | 'base64' | default #BODY_ENCODING
+   * @param  {String} bodyEncoding      'text' | 'base64' | #BODY_ENCODING
    * @return {Object}                   HTTP Response
    */
   response(body = null) {
     return {
-      headers: headers(Buffer.from(body).length),
+      headers: headers(Buffer.from(body).length.toString()),
       body: body || this.statusDescription,
       bodyEncoding: BODY_ENCODING,
       status: this.status,


### PR DESCRIPTION
Allows cloudfront to compress the response if it is large enough.